### PR TITLE
Prevent an incorrect debug message from breaking the addon

### DIFF
--- a/nodeinfo.lua
+++ b/nodeinfo.lua
@@ -10,7 +10,7 @@ This file contains all the various information routines related to flight nodes.
 function EFM_NI_CheckReachable(myNode)
 	local myDebug 		= false;
 
-	EFM_Shared_DebugMessage("Checking if node "..myNode.." is reachable on continent "..myContinent, myDebug);
+	EFM_Shared_DebugMessage("Checking if node "..myNode.." is reachable", myDebug);
 	
 	if (EFM_ReachableNodes ~= nil) then
 		for myContinent in pairs(EFM_ReachableNodes) do


### PR DESCRIPTION
At the indicated line, `myContinent` is undefined. This causes a `nil` concatenation error whenever a flight master is accessed, and prevents the addon from working.