### PR TITLE
Fix recording time that pass throught portals

### DIFF
--- a/EnhancedFlightMap.lua
+++ b/EnhancedFlightMap.lua
@@ -51,6 +51,8 @@ function EnhancedFlightMap_OnEvent( frame, event, ... )
 		-- Register the events we want to listen for
 		frame:RegisterEvent("PLAYER_ENTERING_WORLD");
 		frame:RegisterEvent("PLAYER_LEAVING_WORLD");
+		frame:RegisterEvent("LOADING_SCREEN_DISABLED");
+		frame:RegisterEvent("LOADING_SCREEN_ENABLED");
 
 		-- Register new config screen
 		EnhancedFlightMap_RegConfig(); -- Register New Config
@@ -65,6 +67,15 @@ function EnhancedFlightMap_OnEvent( frame, event, ... )
 		return;
 
 	elseif (event == "PLAYER_ENTERING_WORLD") then
+        local isLogin = select(1, ...);
+        local isReload = select(2, ...);
+        if isLogin then
+            EFM_Shared_DebugMessage("Player entered world for the first time", Lys_Debug);
+        elseif isReload then
+            EFM_Shared_DebugMessage("Player entered world reloaded the UI", Lys_Debug);
+        else
+            EFM_Shared_DebugMessage("Player entered world zoned between map instances", Lys_Debug);
+        end
 		frame:RegisterEvent("TAXIMAP_OPENED");
 		--EFM_Data_NodeFixup();
 		return;
@@ -76,6 +87,15 @@ function EnhancedFlightMap_OnEvent( frame, event, ... )
 	elseif (event == "TAXIMAP_OPENED") then
 		EFM_FM_TaxiMapOpenEvent();
 		return;
+	elseif (event == "LOADING_SCREEN_ENABLED") then
+		-- Loading screen starts, if it happens due to a portal/teleport while in a flight path the recording won't stop but must be paused until the loading screen ends
+        EFM_Shared_DebugMessage("Player loading screen enabled", Lys_Debug);
+        EFM_Timer_PauseTimer();
+        return;
+	elseif (event == "LOADING_SCREEN_DISABLED") then
+        EFM_Shared_DebugMessage("Player loading screen disabled", Lys_Debug);
+        EFM_Timer_ResumeTimer();
+        return;
 	end
 end
 

--- a/Timer.lua
+++ b/Timer.lua
@@ -6,9 +6,24 @@ Code inspired by Kwarz's flightpath.
 
 ]]
 
+function EFM_Timer_PauseTimer()
+	-- Pause the timer at the start of a loading scree while recording
+    if (EFM_Timer_Recording == true) then
+        EFM_Timer_Paused = true;
+    end
+end
+
+function EFM_Timer_ResumeTimer()
+	-- Resume the timer once the loading screen ends
+    EFM_Timer_Paused = false;
+end
+
 -- Function: Update
 function EFM_Timer_EventFrame_OnUpdate()
-	if (EFM_MyConf ~= nil) then
+	-- During loading screens the timer can't be calculated accurately because UnitOnTaxi("player") always return false
+	-- even when the player is going throught the portal for blood elfs starting area in a flight path
+	-- Once the loading screen ends the timer can continue being calculated
+	if (EFM_MyConf ~= nil and not EFM_Timer_Paused) then
 		local ctime;
 		
 		-- Timer Setup/End
@@ -72,16 +87,19 @@ end
 	-- Cancel recording times if we make an emergency landing
 	hooksecurefunc("TaxiRequestEarlyLanding", function()
 		EFM_Timer_Recording = false;
+        EFM_Timer_Paused = false;
 		EFM_Shared_DebugMessage("Player requested early stop.", Lys_Debug);
 	end)
 
 	hooksecurefunc("AcceptBattlefieldPort", function(index, accept)
 		EFM_Timer_Recording = false;
+        EFM_Timer_Paused = false;
 		EFM_Shared_DebugMessage("Player entered BG.", Lys_Debug);
 	end)
 
 	hooksecurefunc(C_SummonInfo, "ConfirmSummon", function()
 		EFM_Timer_Recording = false;
+        EFM_Timer_Paused = false;
 		EFM_Shared_DebugMessage("Player took a summon.", Lys_Debug);
 	end)
 

--- a/globals.lua
+++ b/globals.lua
@@ -17,6 +17,7 @@ EFM_Global_Faction			= UnitFactionGroup("player");
 -- Timer variables (see timer.lua)
 EFM_Timer_StartRecording		= false;
 EFM_Timer_Recording			= false;
+EFM_Timer_Paused			= false;
 EFM_Timer_LastTime			= time();
 EFM_Timer_TimeRemaining			= 0;
 EFM_Timer_TimeKnown			= false;

--- a/nodeinfo.lua
+++ b/nodeinfo.lua
@@ -213,9 +213,19 @@ function EFM_NI_AddNode_FlightDuration(nodeName, destNodeName, flightDuration, n
 
 	-- If no timer set, add one, if one already set, average the two times.
 	if (myNode["timers"][destNodeName] == nil) then
-		myNode["timers"][destNodeName] = flightDuration;
-	else
-		myNode["timers"][destNodeName] = floor((myNode["timers"][destNodeName] + flightDuration) / 2);
+        EFM_Shared_DebugMessage("Adding a new timer", Lys_Debug);
+		myNode["timers"][destNodeName] = flightDuration; 
+    else
+		local avgtime = floor((myNode["timers"][destNodeName] + flightDuration) / 2);
+		if (avgtime > 30) then     
+			-- If there are more than 30 seconds of discrepancy use the last timer without averaging
+			-- The difference is so big that the recorded timer should be incomplete or has been changed by Blizzard
+			EFM_Shared_DebugMessage("Replacing the previous recorded timer that was "..myNode["timers"][destNodeName] , Lys_Debug);
+			myNode["timers"][destNodeName] = flightDuration;   
+		else
+			EFM_Shared_DebugMessage("Averaging timer to "..avgtime.." The previous recorded timer was "..myNode["timers"][destNodeName], Lys_Debug);
+			myNode["timers"][destNodeName] = avgtime;
+		end
 	end
 end
 


### PR DESCRIPTION
I have fixed the problem of recording times on flight paths that have teleports/portals like the one from Ironforge to Quel'danas and those that pass through the portal between Plaguelands and Ghostlands.

Basically, during a loading screen for teleport/portals, while the timer is running, it is not possible to check if the player is in a taxi during that transition. UnitOnTaxi("player") always returns false while the player is on a loading screen, and this causes the recording assumes the player has arrived when the loading screen starts on a flight path.

The solution is to check for LOADING_SCREEN_ENABLED and LOADING_SCREEN_DISABLED and pause the recording between both events. I am unsure if the time the player spends on a loading screen affects the landing time, but the discrepancy should be only a few seconds.

I also changed the code to store the recorded time to replace the stored time instead of averaging if there are more than 30 seconds of difference to make the addon fix previously wrong recorded times on these flight paths. Before this change, the addon recorded in the flight path between Ironforge and Quel'danas 17 seconds, the time it takes for the teleport, while the actual landing happens at around 98 seconds, almost thrice the recorded time. From Ghostlands to Plaguelands, the discrepancy was more than a minute, at least for Alliance.

This PR doesn't affect when a player type /reload to WOW, purging all addon variables, including timer current recording, during reloading, but that only means the flight won't be recorded instead of being recorded with the wrong values.